### PR TITLE
libdfp: powerpc: Fix optimized _Decimal128 implementations

### DIFF
--- a/sysdeps/powerpc/dfpu/ceild128.c
+++ b/sysdeps/powerpc/dfpu/ceild128.c
@@ -24,7 +24,7 @@
 
 _Decimal128 __ceild128 (_Decimal128 x)
 {
-  register _Decimal128 input asm("fr0") = x;
+  register _Decimal128 input asm("fr2") = x;
   _Decimal128 ret;
   asm ("drintnq 1,%0,%1,0\n"
     : "=f"(ret)

--- a/sysdeps/powerpc/dfpu/fabsd128.c
+++ b/sysdeps/powerpc/dfpu/fabsd128.c
@@ -25,8 +25,10 @@ _Decimal128
 __fabsd128 (_Decimal128 x)
 {
   /* Half part os decimal128 constainst the sign bit at same position as
-     binary64, so the instruction works for both formats.  */
-  register _Decimal128 input asm("fr0") = x;
+     binary64, so the instruction works for both formats.  Also for 
+     _Decimal128 the ABI constraint it to odd/even register so it is
+     passed and returned in fr2/fr2.  */
+  register _Decimal128 input asm("fr2") = x;
   _Decimal128 ret;
   asm ("fabs  %1, %0\n"
        : "=f"(ret)

--- a/sysdeps/powerpc/dfpu/floord128.c
+++ b/sysdeps/powerpc/dfpu/floord128.c
@@ -24,7 +24,7 @@
 
 _Decimal128 __floord128 (_Decimal128 x)
 {
-  register _Decimal128 input asm("fr0") = x;
+  register _Decimal128 input asm("fr2") = x;
   _Decimal128 ret;
   asm ("drintnq 1,%0,%1,1\n"
     : "=f"(ret)

--- a/sysdeps/powerpc/dfpu/fpclassifyd128.c
+++ b/sysdeps/powerpc/dfpu/fpclassifyd128.c
@@ -30,7 +30,7 @@ int
 __fpclassifyd128 (_Decimal128 val)
 {
   int result = FP_NAN;
-  register _Decimal128 fr0 asm("fr0") = val;
+  register _Decimal128 fr0 asm("fr2") = val;
 
   /* Check in order, FP_NORMAL, FP_ZERO, FP_SUBNORMAL, FP_INFINITE,
      FP_NAN. The thought is the most likely case exits early. */

--- a/sysdeps/powerpc/dfpu/isfinited128.c
+++ b/sysdeps/powerpc/dfpu/isfinited128.c
@@ -28,7 +28,7 @@
 int
 __isfinited128 (_Decimal128 val)
 {
-  register _Decimal128 input asm("fr0") = val;
+  register _Decimal128 input asm("fr2") = val;
   int cr0;
 
   asm ("dtstdcq cr0,%1,0x38\n"

--- a/sysdeps/powerpc/dfpu/isinfd128.c
+++ b/sysdeps/powerpc/dfpu/isinfd128.c
@@ -26,7 +26,7 @@
 int
 __isinfd128 (_Decimal128 x)
 {
-  register _Decimal128 input asm("fr0") = x;
+  register _Decimal128 input asm("fr2") = x;
   int cr0;
 
   asm ("dtstdcq cr0,%1,0x04\n"

--- a/sysdeps/powerpc/dfpu/isnand128.c
+++ b/sysdeps/powerpc/dfpu/isnand128.c
@@ -27,7 +27,7 @@
 int
 __isnand128 (_Decimal128 val)
 {
-  register _Decimal128 input asm("fr0") = val;
+  register _Decimal128 input asm("fr2") = val;
   int cr0;
 
   asm ("dtstdcq cr0,%1,3\n"

--- a/sysdeps/powerpc/dfpu/isnormald128.c
+++ b/sysdeps/powerpc/dfpu/isnormald128.c
@@ -27,7 +27,7 @@
 int
 __isnormald128 (_Decimal128 x)
 {
-  register _Decimal128 input asm("fr0") = x;
+  register _Decimal128 input asm("fr2") = x;
   int cr0;
 
   asm ("dtstdcq cr0,%1,0x08\n"

--- a/sysdeps/powerpc/dfpu/llquantexpd128.c
+++ b/sysdeps/powerpc/dfpu/llquantexpd128.c
@@ -28,7 +28,7 @@ long long int
 __llquantexpd128 (_Decimal128 x)
 {
   long long int ret;
-  register _Decimal128 input asm("fr0") = x;
+  register _Decimal128 input asm("fr2") = x;
   _Decimal128 r;
   asm ("dxexq   %0,%1\n"
        "dcffixq %0,%0\n"

--- a/sysdeps/powerpc/dfpu/nearbyintd128.c
+++ b/sysdeps/powerpc/dfpu/nearbyintd128.c
@@ -24,7 +24,7 @@
 
 _Decimal128 __nearbyintd128 (_Decimal128 x)
 {
-  register _Decimal128 input asm("fr0") = x;
+  register _Decimal128 input asm("fr2") = x;
   _Decimal128 ret;
   asm ("drintnq 0,%0,%1,3\n"
     : "=f"(ret)

--- a/sysdeps/powerpc/dfpu/quantumd128.c
+++ b/sysdeps/powerpc/dfpu/quantumd128.c
@@ -25,7 +25,7 @@
 /* Return the quantum 1 * 10^exponent(x)  */
 _Decimal128 __quantumd128 (_Decimal128 x)
 {
-  register _Decimal128 input asm("fr0") = x;
+  register _Decimal128 input asm("fr2") = x;
   _Decimal128 ret;
   _Decimal128 ref = 1e-6176DL;
   asm ("dxexq   %1,%1\n"      /* Extract exponent  */

--- a/sysdeps/powerpc/dfpu/rintd128.c
+++ b/sysdeps/powerpc/dfpu/rintd128.c
@@ -22,7 +22,7 @@
 
 _Decimal128 __rintd128 (_Decimal128 a)
 {
-  register _Decimal128 fr0 asm("fr0") = a;
+  register _Decimal128 fr0 asm("fr2") = a;
   asm (
    "drintxq 0,%0,%0,3\n\t"
    : "=f"(fr0) : "0"(fr0));

--- a/sysdeps/powerpc/dfpu/roundd128.c
+++ b/sysdeps/powerpc/dfpu/roundd128.c
@@ -24,7 +24,7 @@
 
 _Decimal128 __roundd128 (_Decimal128 x)
 {
-  register _Decimal128 input asm("fr0") = x;
+  register _Decimal128 input asm("fr2") = x;
   _Decimal128 ret;
   asm ("drintnq 0,%0,%1,2\n"
     : "=f"(ret)

--- a/sysdeps/powerpc/dfpu/roundevend128.c
+++ b/sysdeps/powerpc/dfpu/roundevend128.c
@@ -24,7 +24,7 @@
 
 _Decimal128 __roundevend128 (_Decimal128 x)
 {
-  register _Decimal128 input asm("fr0") = x;
+  register _Decimal128 input asm("fr2") = x;
   _Decimal128 ret;
   asm ("drintnq 0,%0,%1,0\n"
     : "=f"(ret)

--- a/sysdeps/powerpc/dfpu/truncd128.c
+++ b/sysdeps/powerpc/dfpu/truncd128.c
@@ -24,7 +24,7 @@
 
 _Decimal128 __truncd128 (_Decimal128 x)
 {
-  register _Decimal128 input asm("fr0") = x;
+  register _Decimal128 input asm("fr2") = x;
   _Decimal128 ret;
   asm ("drintnq 0,%0,%1,1\n"
     : "=f"(ret)


### PR DESCRIPTION
This patch changes the expected input register to _Decimal128 to
correct fr2 instead of fr0 (since ABI states _Decimal128 should
be passed in odd/even registers) on various powerpc implementations.

Signed-off-by: Adhemerval Zanella  <adhemerval.zanella@linaro.org>